### PR TITLE
Ensure line endings are normalized to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[core]
+    autocrlf=false


### PR DESCRIPTION
This disables autocrlf locally and ensures everything is normalized to LF line endings via .gitattributes. Very annoying to do things like stashing otherwise without ESLint getting on my butt lol